### PR TITLE
feat: support worktree start without tmux

### DIFF
--- a/apps/cli/schemas/config-schema.json
+++ b/apps/cli/schemas/config-schema.json
@@ -133,6 +133,10 @@
           "items": {
             "type": "string"
           }
+        },
+        "tmux": {
+          "type": "boolean",
+          "description": "Whether worktree commands should create, switch, and kill tmux sessions. Defaults to true when omitted."
         }
       }
     },
@@ -160,6 +164,10 @@
           "items": {
             "type": "string"
           }
+        },
+        "tmux": {
+          "type": "boolean",
+          "description": "Whether worktree commands should create, switch, and kill tmux sessions for this workspace. Overrides the global worktree setting when present."
         }
       }
     }

--- a/apps/cli/src/commands/worktree/complete.rs
+++ b/apps/cli/src/commands/worktree/complete.rs
@@ -217,7 +217,11 @@ impl WorktreeCompleteCommand {
 
         // ===== PHASE 2: DETERMINE EXECUTION FLOW =====
 
-        let current_session = get_current_tmux_session();
+        let current_session = if merged_config.tmux {
+            get_current_tmux_session()
+        } else {
+            None
+        };
         let target_session_name = calculate_worktree_session_name(workspace, &branch_name);
         let is_self_deletion = current_session.as_ref() == Some(&target_session_name);
 
@@ -468,15 +472,20 @@ fn execute_cleanup_directly(
     let should_switch_client = current_dir.starts_with(worktree_path);
 
     // 4. If we're in the worktree being deleted, switch client first
-    if should_switch_client && let Some(ws) = workspace {
+    if merged_config.tmux
+        && should_switch_client
+        && let Some(ws) = workspace
+    {
         switch_to_main_workspace_session(session_repository, client_repository, &ws.name);
         println!("Switched to main workspace session");
     }
 
-    // 5. Kill the worktree's tmux session
-    let session_name = calculate_worktree_session_name(workspace, branch_name);
-    kill_session_by_name(session_repository, &session_name);
-    println!("Closed tmux session: {}", session_name);
+    // 5. Kill the worktree's tmux session when tmux integration is enabled
+    if merged_config.tmux {
+        let session_name = calculate_worktree_session_name(workspace, branch_name);
+        kill_session_by_name(session_repository, &session_name);
+        println!("Closed tmux session: {}", session_name);
+    }
 
     // 6. Change directory away from worktree if needed
     if current_dir.starts_with(worktree_path)

--- a/apps/cli/src/commands/worktree/start.rs
+++ b/apps/cli/src/commands/worktree/start.rs
@@ -66,7 +66,8 @@ pub enum WorktreeStartResult {
     /// Worktree was created but onCreate commands failed
     PartialSuccess {
         worktree_path: String,
-        session_name: String,
+        session_name: Option<String>,
+        tmux_enabled: bool,
         failed_command: String,
         error: String,
     },
@@ -97,11 +98,18 @@ impl RafaeltabCommand<WorktreeStartOptions<'_>> for WorktreeStartCommand {
             WorktreeStartResult::PartialSuccess {
                 worktree_path,
                 session_name,
+                tmux_enabled,
                 failed_command,
                 error,
             } => {
                 println!("✓ Created worktree at {}", worktree_path);
-                println!("✓ Created tmux session: {} (not switched)", session_name);
+                if tmux_enabled {
+                    if let Some(session_name) = session_name {
+                        println!("✓ Created tmux session: {} (not switched)", session_name);
+                    }
+                } else {
+                    println!("ℹ Skipped tmux integration (--no-tmux or worktree.tmux=false)");
+                }
                 println!();
                 println!("⚠ onCreate command failed: {}", failed_command);
                 println!("  Error: {}", error);
@@ -238,6 +246,14 @@ impl WorktreeStartCommand {
                 creation_info.config.on_create.len(),
                 creation_info.config.on_create.join(", ")
             );
+            println!(
+                "  Tmux: {}",
+                if creation_info.config.tmux {
+                    "enabled"
+                } else {
+                    "disabled"
+                }
+            );
             println!();
 
             let confirmed = Confirm::new("Continue?").with_default(true).prompt();
@@ -337,7 +353,12 @@ impl WorktreeStartCommand {
         if let Some((failed_cmd, error)) = on_create_failed {
             return WorktreeStartResult::PartialSuccess {
                 worktree_path: worktree_path.display().to_string(),
-                session_name,
+                session_name: if merged_config.tmux {
+                    Some(session_name)
+                } else {
+                    None
+                },
+                tmux_enabled: merged_config.tmux,
                 failed_command: failed_cmd,
                 error,
             };

--- a/apps/cli/src/commands/worktree/start.rs
+++ b/apps/cli/src/commands/worktree/start.rs
@@ -41,6 +41,8 @@ pub struct WorktreeStartOptions<'a> {
     pub skip_config: bool,
     /// Skip confirmation prompt
     pub yes: bool,
+    /// Disable tmux integration for this invocation
+    pub no_tmux: bool,
     /// Repository for workspace operations
     pub workspace_repository: &'a dyn WorkspaceRepository,
     /// Storage for global worktree config
@@ -58,7 +60,8 @@ pub enum WorktreeStartResult {
     /// Worktree was created successfully and tmux session was started
     Success {
         worktree_path: String,
-        session_name: String,
+        session_name: Option<String>,
+        tmux_enabled: bool,
     },
     /// Worktree was created but onCreate commands failed
     PartialSuccess {
@@ -80,9 +83,16 @@ impl RafaeltabCommand<WorktreeStartOptions<'_>> for WorktreeStartCommand {
             WorktreeStartResult::Success {
                 worktree_path,
                 session_name,
+                tmux_enabled,
             } => {
                 println!("✓ Created worktree at {}", worktree_path);
-                println!("✓ Started tmux session: {}", session_name);
+                if tmux_enabled {
+                    if let Some(session_name) = session_name {
+                        println!("✓ Started tmux session: {}", session_name);
+                    }
+                } else {
+                    println!("ℹ Skipped tmux integration (--no-tmux or worktree.tmux=false)");
+                }
             }
             WorktreeStartResult::PartialSuccess {
                 worktree_path,
@@ -165,8 +175,11 @@ impl WorktreeStartCommand {
         }
 
         // 6. Merge configurations
-        let merged_config =
+        let mut merged_config =
             MergedWorktreeConfig::merge(global_config.as_ref(), workspace_config.as_ref());
+        if options.no_tmux {
+            merged_config.tmux = false;
+        }
 
         // 7. Get current branch (base branch)
         let base_branch = match git::get_current_branch(&git_root) {
@@ -305,17 +318,20 @@ impl WorktreeStartCommand {
             }
         }
 
-        // 16. Create tmux session
+        // 16. Optionally create tmux session
         let session_name = format!("{}-{}", workspace.name, options.branch_name);
-
-        // Create a session description for the worktree
-        let session = create_tmux_session(
-            options.session_repository,
-            &session_name,
-            &worktree_path,
-            &workspace.id,
-            options.tmux_storage,
-        );
+        let session = if merged_config.tmux {
+            // Create a session description for the worktree
+            create_tmux_session(
+                options.session_repository,
+                &session_name,
+                &worktree_path,
+                &workspace.id,
+                options.tmux_storage,
+            )
+        } else {
+            None
+        };
 
         // 17. If onCreate failed, don't switch to session
         if let Some((failed_cmd, error)) = on_create_failed {
@@ -336,7 +352,12 @@ impl WorktreeStartCommand {
 
         WorktreeStartResult::Success {
             worktree_path: worktree_path.display().to_string(),
-            session_name,
+            session_name: if merged_config.tmux {
+                Some(session_name)
+            } else {
+                None
+            },
+            tmux_enabled: merged_config.tmux,
         }
     }
 }
@@ -431,6 +452,7 @@ mod tests {
             symlink_files: vec![".env.local".to_string()],
             on_create: vec!["pnpm install".to_string()],
             on_destroy: vec![],
+            tmux: None,
         };
 
         let workspace_storage = MockWorkspaceStorage {
@@ -515,6 +537,7 @@ mod tests {
             symlink_files: vec![".env.local".to_string()],
             on_create: vec!["pnpm install".to_string()],
             on_destroy: vec![],
+            tmux: None,
         };
 
         let workspace_storage = MockWorkspaceStorage {
@@ -536,6 +559,7 @@ mod tests {
             symlink_files: vec![".env".to_string(), "config.json".to_string()],
             on_create: vec!["npm ci".to_string()],
             on_destroy: vec![],
+            tmux: None,
         };
 
         // Get workspace config and merge with global
@@ -575,6 +599,7 @@ mod tests {
             symlink_files: vec![".env".to_string()],
             on_create: vec!["npm install".to_string()],
             on_destroy: vec![],
+            tmux: None,
         };
 
         // Merge with no workspace config
@@ -595,6 +620,7 @@ mod tests {
             symlink_files: vec!["package.json".to_string()],
             on_create: vec!["yarn install".to_string()],
             on_destroy: vec![],
+            tmux: None,
         };
 
         let workspace_storage = MockWorkspaceStorage {

--- a/apps/cli/src/domain/worktree/config.rs
+++ b/apps/cli/src/domain/worktree/config.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 use crate::storage::worktree::{WorkspaceWorktreeConfig, WorktreeConfig};
 
 /// Merged worktree configuration from global and workspace-specific settings
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct MergedWorktreeConfig {
     /// Combined symlink file patterns (global + workspace)
     pub symlink_files: Vec<String>,
@@ -13,6 +13,19 @@ pub struct MergedWorktreeConfig {
     pub on_create: Vec<String>,
     /// Combined onDestroy commands (global + workspace)
     pub on_destroy: Vec<String>,
+    /// Whether worktree commands should create/switch/kill tmux sessions.
+    pub tmux: bool,
+}
+
+impl Default for MergedWorktreeConfig {
+    fn default() -> Self {
+        Self {
+            symlink_files: Vec::new(),
+            on_create: Vec::new(),
+            on_destroy: Vec::new(),
+            tmux: true,
+        }
+    }
 }
 
 impl MergedWorktreeConfig {
@@ -26,12 +39,16 @@ impl MergedWorktreeConfig {
         let mut symlink_files = Vec::new();
         let mut on_create = Vec::new();
         let mut on_destroy = Vec::new();
+        let mut tmux = true;
 
         // Add global config first
         if let Some(global_config) = global {
             symlink_files.extend(global_config.symlink_files.clone());
             on_create.extend(global_config.on_create.clone());
             on_destroy.extend(global_config.on_destroy.clone());
+            if let Some(global_tmux) = global_config.tmux {
+                tmux = global_tmux;
+            }
         }
 
         // Add workspace-specific config (these come after global)
@@ -52,12 +69,16 @@ impl MergedWorktreeConfig {
                     on_destroy.push(cmd.clone());
                 }
             }
+            if let Some(workspace_tmux) = workspace_config.tmux {
+                tmux = workspace_tmux;
+            }
         }
 
         MergedWorktreeConfig {
             symlink_files,
             on_create,
             on_destroy,
+            tmux,
         }
     }
 
@@ -158,11 +179,13 @@ mod tests {
             symlink_files: vec![".env".to_string()],
             on_create: vec![],
             on_destroy: vec![],
+            tmux: None,
         };
         let workspace = WorkspaceWorktreeConfig {
             symlink_files: vec!["secrets.json".to_string()],
             on_create: vec![],
             on_destroy: vec![],
+            tmux: None,
         };
 
         let result = MergedWorktreeConfig::merge(Some(&global), Some(&workspace));
@@ -176,11 +199,13 @@ mod tests {
             symlink_files: vec![],
             on_create: vec!["npm install".to_string()],
             on_destroy: vec![],
+            tmux: None,
         };
         let workspace = WorkspaceWorktreeConfig {
             symlink_files: vec![],
             on_create: vec!["npm run build".to_string()],
             on_destroy: vec![],
+            tmux: None,
         };
 
         let result = MergedWorktreeConfig::merge(Some(&global), Some(&workspace));
@@ -194,11 +219,13 @@ mod tests {
             symlink_files: vec![".env".to_string(), "config.json".to_string()],
             on_create: vec![],
             on_destroy: vec![],
+            tmux: None,
         };
         let workspace = WorkspaceWorktreeConfig {
             symlink_files: vec![".env".to_string(), "secrets.json".to_string()],
             on_create: vec![],
             on_destroy: vec![],
+            tmux: None,
         };
 
         let result = MergedWorktreeConfig::merge(Some(&global), Some(&workspace));
@@ -215,6 +242,7 @@ mod tests {
             symlink_files: vec![".env".to_string()],
             on_create: vec!["npm install".to_string()],
             on_destroy: vec![],
+            tmux: None,
         };
 
         let result = MergedWorktreeConfig::merge(None, Some(&workspace));
@@ -229,6 +257,7 @@ mod tests {
             symlink_files: vec![".env".to_string()],
             on_create: vec!["npm install".to_string()],
             on_destroy: vec![],
+            tmux: None,
         };
 
         let result = MergedWorktreeConfig::merge(Some(&global), None);
@@ -253,11 +282,13 @@ mod tests {
             symlink_files: vec![],
             on_create: vec![],
             on_destroy: vec!["npm run cleanup".to_string()],
+            tmux: None,
         };
         let workspace = WorkspaceWorktreeConfig {
             symlink_files: vec![],
             on_create: vec![],
             on_destroy: vec!["rm -rf node_modules".to_string()],
+            tmux: None,
         };
 
         let result = MergedWorktreeConfig::merge(Some(&global), Some(&workspace));
@@ -274,11 +305,13 @@ mod tests {
             symlink_files: vec![],
             on_create: vec![],
             on_destroy: vec!["npm run cleanup".to_string(), "rm temp".to_string()],
+            tmux: None,
         };
         let workspace = WorkspaceWorktreeConfig {
             symlink_files: vec![],
             on_create: vec![],
             on_destroy: vec!["npm run cleanup".to_string(), "rm logs".to_string()],
+            tmux: None,
         };
 
         let result = MergedWorktreeConfig::merge(Some(&global), Some(&workspace));
@@ -290,11 +323,39 @@ mod tests {
     }
 
     #[test]
+    fn test_merge_configs_workspace_tmux_overrides_global() {
+        let global = WorktreeConfig {
+            symlink_files: vec![],
+            on_create: vec![],
+            on_destroy: vec![],
+            tmux: Some(true),
+        };
+        let workspace = WorkspaceWorktreeConfig {
+            symlink_files: vec![],
+            on_create: vec![],
+            on_destroy: vec![],
+            tmux: Some(false),
+        };
+
+        let result = MergedWorktreeConfig::merge(Some(&global), Some(&workspace));
+
+        assert!(!result.tmux);
+    }
+
+    #[test]
+    fn test_merge_configs_defaults_tmux_to_enabled() {
+        let result = MergedWorktreeConfig::merge(None, None);
+
+        assert!(result.tmux);
+    }
+
+    #[test]
     fn test_merge_configs_on_destroy_no_global() {
         let workspace = WorkspaceWorktreeConfig {
             symlink_files: vec![],
             on_create: vec![],
             on_destroy: vec!["rm -rf dist".to_string()],
+            tmux: None,
         };
 
         let result = MergedWorktreeConfig::merge(None, Some(&workspace));
@@ -308,6 +369,7 @@ mod tests {
             symlink_files: vec![],
             on_create: vec![],
             on_destroy: vec!["npm run cleanup".to_string()],
+            tmux: None,
         };
 
         let result = MergedWorktreeConfig::merge(Some(&global), None);
@@ -321,6 +383,7 @@ mod tests {
             symlink_files: vec![],
             on_create: vec![],
             on_destroy: vec!["npm run cleanup".to_string()],
+            tmux: true,
         };
         assert!(!config.is_empty());
     }
@@ -385,6 +448,7 @@ mod tests {
             symlink_files: vec![".env".to_string()],
             on_create: vec![],
             on_destroy: vec![],
+            tmux: true,
         };
         assert!(!config.is_empty());
     }
@@ -395,6 +459,7 @@ mod tests {
             symlink_files: vec![],
             on_create: vec!["npm install".to_string()],
             on_destroy: vec![],
+            tmux: true,
         };
         assert!(!config.is_empty());
     }

--- a/apps/cli/src/infrastructure/tmux_workspaces/repositories/workspace/workspace_repository.rs
+++ b/apps/cli/src/infrastructure/tmux_workspaces/repositories/workspace/workspace_repository.rs
@@ -188,6 +188,7 @@ mod test {
             symlink_files: vec![".env".to_string(), "config.json".to_string()],
             on_create: vec!["npm install".to_string()],
             on_destroy: vec![],
+            tmux: None,
         };
 
         let workspace_storage = MockWorkspaceStorage {

--- a/apps/cli/src/main.rs
+++ b/apps/cli/src/main.rs
@@ -203,6 +203,10 @@ struct WorktreeStartArgs {
     /// Skip confirmation prompt
     #[arg(short = 'y', long)]
     yes: bool,
+
+    /// Disable tmux integration for this worktree
+    #[arg(long)]
+    no_tmux: bool,
 }
 
 #[derive(Debug, Args)]
@@ -353,6 +357,7 @@ fn main() -> Result<(), io::Error> {
                         branch_name: args.branch_name.clone(),
                         skip_config: args.skip_config,
                         yes: args.yes,
+                        no_tmux: args.no_tmux,
                         workspace_repository,
                         worktree_storage: &storage,
                         session_repository: tmux_repository,

--- a/apps/cli/src/storage/worktree.rs
+++ b/apps/cli/src/storage/worktree.rs
@@ -18,6 +18,10 @@ pub struct WorktreeConfig {
     /// Commands to run when destroying a worktree
     #[serde(default)]
     pub on_destroy: Vec<String>,
+    /// Whether worktree commands should integrate with tmux.
+    /// Defaults to true when omitted.
+    #[serde(default)]
+    pub tmux: Option<bool>,
 }
 
 /// Per-workspace worktree configuration
@@ -36,6 +40,10 @@ pub struct WorkspaceWorktreeConfig {
     /// These are merged with global on_destroy commands
     #[serde(default)]
     pub on_destroy: Vec<String>,
+    /// Whether worktree commands should integrate with tmux.
+    /// Overrides the global worktree setting when present.
+    #[serde(default)]
+    pub tmux: Option<bool>,
 }
 
 #[cfg(test)]
@@ -112,6 +120,7 @@ mod tests {
             symlink_files: vec![".env".to_string()],
             on_create: vec!["npm install".to_string()],
             on_destroy: vec![],
+            tmux: None,
         };
 
         let json = serde_json::to_string(&config).unwrap();
@@ -165,6 +174,28 @@ mod tests {
     }
 
     #[test]
+    fn test_deserialize_worktree_config_with_tmux_disabled() {
+        let json = r#"{
+            "tmux": false
+        }"#;
+
+        let config: WorktreeConfig = serde_json::from_str(json).unwrap();
+
+        assert_eq!(config.tmux, Some(false));
+    }
+
+    #[test]
+    fn test_deserialize_workspace_worktree_config_with_tmux_disabled() {
+        let json = r#"{
+            "tmux": false
+        }"#;
+
+        let config: WorkspaceWorktreeConfig = serde_json::from_str(json).unwrap();
+
+        assert_eq!(config.tmux, Some(false));
+    }
+
+    #[test]
     fn test_on_destroy_defaults_to_empty() {
         let json = r#"{}"#;
 
@@ -181,6 +212,7 @@ mod tests {
             symlink_files: vec![],
             on_create: vec![],
             on_destroy: vec!["npm run cleanup".to_string()],
+            tmux: None,
         };
 
         let json = serde_json::to_string(&config).unwrap();

--- a/apps/cli/tests/config_file_tests.rs
+++ b/apps/cli/tests/config_file_tests.rs
@@ -51,6 +51,24 @@ fn test_config_file_with_all_fields() {
 }
 
 #[test]
+fn test_config_schema_documents_worktree_tmux_settings() {
+    let schema_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("schemas")
+        .join("config-schema.json");
+    let schema: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(schema_path).unwrap()).unwrap();
+
+    assert_eq!(
+        schema["definitions"]["WorktreeConfig"]["properties"]["tmux"]["type"],
+        "boolean"
+    );
+    assert_eq!(
+        schema["definitions"]["WorkspaceWorktreeConfig"]["properties"]["tmux"]["type"],
+        "boolean"
+    );
+}
+
+#[test]
 fn test_config_file_minimal_valid() {
     let env = TestEnvironment::describe(|root| {
         root.rafaeltab_config(|_c| {});

--- a/apps/cli/tests/worktree_start_additional_tests.rs
+++ b/apps/cli/tests/worktree_start_additional_tests.rs
@@ -48,6 +48,57 @@ fn test_worktree_start_force_flag_removed() {
 }
 
 #[test]
+fn test_worktree_start_no_tmux_skips_session_creation_and_switch() {
+    let env = TestEnvironment::describe(|root| {
+        root.rafaeltab_config(|_c| {});
+
+        root.test_dir(|td| {
+            td.dir("no_tmux_wt", |d| {
+                d.git("repo", |g| {
+                    g.branch("main", |b| {
+                        b.commit("Initial commit", |c| {
+                            c.file("README.md", "# Test");
+                        });
+                    });
+
+                    g.rafaeltab_workspace("repo", "Repo", |w| {
+                        w.worktree(&[], &[], &[]);
+                    });
+                });
+            });
+        });
+    })
+    .create();
+
+    let repo_dir = env.find_dir("no_tmux_wt").expect("Dir not found");
+    let cmd = CliCommandBuilder::new()
+        .with_env(&env)
+        .with_cwd(repo_dir.path().join("repo"))
+        .args(&["worktree", "start", "agent-branch", "--no-tmux", "--yes"])
+        .build();
+    let result = env.testers().cmd().run(&cmd);
+
+    assert!(
+        result.success,
+        "--no-tmux should not require an attached tmux client. Got: {} {}",
+        result.stdout, result.stderr
+    );
+    assert!(
+        result.stdout.contains("Skipped tmux integration"),
+        "Expected output to mention skipped tmux integration. Got: {}",
+        result.stdout
+    );
+    assert!(
+        repo_dir.path().join("agent-branch").exists(),
+        "worktree path should still be created"
+    );
+    assert!(
+        !env.tmux().session_exists("Repo-agent-branch"),
+        "--no-tmux should not create a tmux session"
+    );
+}
+
+#[test]
 fn test_worktree_start_skip_config_works() {
     let env = TestEnvironment::describe(|root| {
         root.rafaeltab_config(|_c| {});

--- a/apps/cli/tests/worktree_start_additional_tests.rs
+++ b/apps/cli/tests/worktree_start_additional_tests.rs
@@ -99,6 +99,100 @@ fn test_worktree_start_no_tmux_skips_session_creation_and_switch() {
 }
 
 #[test]
+fn test_worktree_start_no_tmux_oncreate_failure_does_not_report_created_tmux_session() {
+    let env = TestEnvironment::describe(|root| {
+        root.rafaeltab_config(|c| {
+            c.worktree_global(&["exit 1"], &[], &[]);
+        });
+
+        root.test_dir(|td| {
+            td.dir("no_tmux_oncreate_fail", |d| {
+                d.git("repo", |g| {
+                    g.branch("main", |b| {
+                        b.commit("Initial commit", |c| {
+                            c.file("README.md", "# Test");
+                        });
+                    });
+
+                    g.rafaeltab_workspace("repo", "Repo", |_| {});
+                });
+            });
+        });
+    })
+    .create();
+
+    let repo_dir = env
+        .find_dir("no_tmux_oncreate_fail")
+        .expect("Dir not found");
+    let cmd = CliCommandBuilder::new()
+        .with_env(&env)
+        .with_cwd(repo_dir.path().join("repo"))
+        .args(&["worktree", "start", "failed-branch", "--no-tmux", "--yes"])
+        .build();
+    let result = env.testers().cmd().run(&cmd);
+
+    assert!(
+        result.success,
+        "onCreate failure should be reported without process failure. Got: {} {}",
+        result.stdout, result.stderr
+    );
+    assert!(
+        result.stdout.contains("Skipped tmux integration"),
+        "Expected output to mention skipped tmux integration. Got: {}",
+        result.stdout
+    );
+    assert!(
+        !result.stdout.contains("Created tmux session"),
+        "--no-tmux must not report a tmux session when onCreate fails. Got: {}",
+        result.stdout
+    );
+}
+
+#[test]
+fn test_worktree_start_confirmation_displays_tmux_status() {
+    let env = TestEnvironment::describe(|root| {
+        root.rafaeltab_config(|_c| {});
+
+        root.test_dir(|td| {
+            td.dir("no_tmux_confirm", |d| {
+                d.git("repo", |g| {
+                    g.branch("main", |b| {
+                        b.commit("Initial commit", |c| {
+                            c.file("README.md", "# Test");
+                        });
+                    });
+
+                    g.rafaeltab_workspace("repo", "Repo", |w| {
+                        w.worktree(&[], &[], &[]);
+                    });
+                });
+            });
+        });
+    })
+    .create();
+
+    let repo_dir = env.find_dir("no_tmux_confirm").expect("Dir not found");
+    let cmd = CliCommandBuilder::new()
+        .with_env(&env)
+        .with_cwd(repo_dir.path().join("repo"))
+        .args(&["worktree", "start", "confirm-branch", "--no-tmux"])
+        .stdin("n\n")
+        .build();
+    let result = env.testers().cmd().run(&cmd);
+
+    assert!(
+        result.success,
+        "Cancelling at confirmation should exit successfully. Got: {} {}",
+        result.stdout, result.stderr
+    );
+    assert!(
+        result.stdout.contains("Tmux: disabled"),
+        "Confirmation should show tmux status. Got: {}",
+        result.stdout
+    );
+}
+
+#[test]
 fn test_worktree_start_skip_config_works() {
     let env = TestEnvironment::describe(|root| {
         root.rafaeltab_config(|_c| {});


### PR DESCRIPTION
## Summary
- add `rafaeltab worktree start --no-tmux` to create git worktrees without creating/switching tmux sessions
- add `worktree.tmux` config merging with workspace overrides, defaulting to enabled for existing configs
- skip tmux session detection/switch/kill during `worktree complete` when tmux integration is disabled by config
- cover the no-tmux flow plus config deserialize/merge behavior with tests

Closes #45

## Verification
- `cargo fmt`
- `cargo test`
